### PR TITLE
ENG-11170 Add TIMESTAMP as Data Type option for Calculated Columns in Data Source Editor for Superset charts

### DIFF
--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -25,7 +25,7 @@ import './main.css';
 
 const checkboxGenerator = (d, onChange) => <CheckboxControl value={d} onChange={onChange} />;
 const styleMonospace = { fontFamily: 'monospace' };
-const DATA_TYPES = ['STRING', 'NUMBER', 'DATETIME'];
+const DATA_TYPES = ['STRING', 'NUMBER', 'DATETIME', 'TIMESTAMP'];
 
 function CollectionTabTitle({ title, collection }) {
   return (


### PR DESCRIPTION
https://analyticsmd.atlassian.net/browse/ENG-11170

This was a pretty simple change. Screenshots of the new dropdown option are below:
![2018-12-03-132808_1328x1054_scrot](https://user-images.githubusercontent.com/907925/49402715-6f590b00-f6ff-11e8-8383-d89ae737cd06.png)
![2018-12-03-132848_1328x1054_scrot](https://user-images.githubusercontent.com/907925/49402722-72ec9200-f6ff-11e8-8216-9970e15ea628.png)

