### PR TITLE
ENG-11188 Datasource modal save is overwriting template parameters

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -323,7 +323,8 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
         which can be defined for each connector and
         defines which fields should be synced"""
         for attr in self.update_from_object_fields:
-            setattr(self, attr, obj.get(attr))
+            if obj.get(attr):
+                setattr(self, attr, obj.get(attr))
 
         self.user_id = obj.get('owner')
 

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -323,8 +323,10 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
         which can be defined for each connector and
         defines which fields should be synced"""
         for attr in self.update_from_object_fields:
-            if obj.get(attr):
-                setattr(self, attr, obj.get(attr))
+            try:
+                setattr(self, attr, obj[attr])
+            except KeyError:
+                continue
 
         self.user_id = obj.get('owner')
 


### PR DESCRIPTION
https://analyticsmd.atlassian.net/browse/ENG-11188
@analyticsMD/webapps 

## Summary
### Problem
When editing the datasource via chart modal, the template parameters field is cleared even though the user didn't specify or delete template parameters.

### Solution
Followed the ajax post request and found the save endpoint for the datasource modal. The datasource object is being updated through a method called `update_from_object`, which takes in a new object as an argument parameter. The method goes through each attribute on `self` and sets is to the corresponding attribute found on the new object. The issue here is that if the new object doesn't have an attribute found on the original object, the value is overwritten with None. The solution is to simply add a try/except block with a key lookup instead of a json getter. This way we'll only set the attributes that exist.

### Acceptance Criteria
- [x] Template parameters are no longer cleared when using the datasource modal
- [x] All other attributes are unaffected by this change
